### PR TITLE
Add basic Factur-X XML generator microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # facturx-gen
+
+Simple microservice to build minimal Factur-X (BASIC profile) XML invoices from structured JSON.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the service:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+POST invoice data to `/generate_facturx` to receive Factur-X XML.

--- a/app/builder.py
+++ b/app/builder.py
@@ -1,0 +1,87 @@
+from lxml import etree
+from typing import List
+
+NSMAP = {
+    'rsm': 'urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100',
+    'ram': 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100',
+    'qdt': 'urn:un:unece:uncefact:data:standard:QualifiedDataType:100',
+    'udt': 'urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100',
+}
+
+
+def build_facturx_basic(invoice: dict) -> str:
+    """Build a minimal Factur-X BASIC profile XML from invoice data."""
+    root = etree.Element(f"{{{NSMAP['rsm']}}}CrossIndustryInvoice", nsmap=NSMAP)
+
+    ctx = etree.SubElement(root, f"{{{NSMAP['rsm']}}}ExchangedDocumentContext")
+    guideline = etree.SubElement(ctx, f"{{{NSMAP['ram']}}}GuidelineSpecifiedDocumentContextParameter")
+    etree.SubElement(guideline, f"{{{NSMAP['ram']}}}ID").text = "urn:factur-x.eu:1p0:basic"
+
+    doc = etree.SubElement(root, f"{{{NSMAP['rsm']}}}ExchangedDocument")
+    etree.SubElement(doc, f"{{{NSMAP['ram']}}}ID").text = invoice['invoice_id']
+    etree.SubElement(doc, f"{{{NSMAP['ram']}}}TypeCode").text = '380'
+    issue_dt = etree.SubElement(doc, f"{{{NSMAP['ram']}}}IssueDateTime")
+    etree.SubElement(issue_dt, f"{{{NSMAP['udt']}}}DateTimeString", format="102").text = invoice['issue_date']
+
+    trn = etree.SubElement(root, f"{{{NSMAP['rsm']}}}SupplyChainTradeTransaction")
+    line_total = 0.0
+    tax_total = 0.0
+
+    for idx, item in enumerate(invoice['items'], 1):
+        line = etree.SubElement(trn, f"{{{NSMAP['ram']}}}IncludedSupplyChainTradeLineItem")
+        doc_line = etree.SubElement(line, f"{{{NSMAP['ram']}}}AssociatedDocumentLineDocument")
+        etree.SubElement(doc_line, f"{{{NSMAP['ram']}}}LineID").text = str(idx)
+
+        prod = etree.SubElement(line, f"{{{NSMAP['ram']}}}SpecifiedTradeProduct")
+        etree.SubElement(prod, f"{{{NSMAP['ram']}}}Name").text = item['name']
+
+        agr = etree.SubElement(line, f"{{{NSMAP['ram']}}}SpecifiedLineTradeAgreement")
+        gross = etree.SubElement(agr, f"{{{NSMAP['ram']}}}GrossPriceProductTradePrice")
+        etree.SubElement(gross, f"{{{NSMAP['ram']}}}ChargeAmount").text = f"{item['price']:.2f}"
+        net = etree.SubElement(agr, f"{{{NSMAP['ram']}}}NetPriceProductTradePrice")
+        etree.SubElement(net, f"{{{NSMAP['ram']}}}ChargeAmount").text = f"{item['price']:.2f}"
+
+        delivery = etree.SubElement(line, f"{{{NSMAP['ram']}}}SpecifiedLineTradeDelivery")
+        etree.SubElement(
+            delivery,
+            f"{{{NSMAP['ram']}}}BilledQuantity",
+            unitCode=item.get('unit_code', 'C62'),
+        ).text = str(item['quantity'])
+
+        settle = etree.SubElement(line, f"{{{NSMAP['ram']}}}SpecifiedLineTradeSettlement")
+        tax = etree.SubElement(settle, f"{{{NSMAP['ram']}}}ApplicableTradeTax")
+        etree.SubElement(tax, f"{{{NSMAP['ram']}}}TypeCode").text = 'VAT'
+        etree.SubElement(tax, f"{{{NSMAP['ram']}}}CategoryCode").text = 'S'
+        etree.SubElement(tax, f"{{{NSMAP['ram']}}}RateApplicablePercent").text = f"{item['tax_rate']:.2f}"
+
+        line_amount = item['quantity'] * item['price']
+        line_total += line_amount
+        tax_total += line_amount * item['tax_rate'] / 100
+
+        line_sum = etree.SubElement(settle, f"{{{NSMAP['ram']}}}SpecifiedTradeSettlementLineMonetarySummation")
+        etree.SubElement(line_sum, f"{{{NSMAP['ram']}}}LineTotalAmount").text = f"{line_amount:.2f}"
+
+    agreement = etree.SubElement(trn, f"{{{NSMAP['ram']}}}ApplicableHeaderTradeAgreement")
+    seller = etree.SubElement(agreement, f"{{{NSMAP['ram']}}}SellerTradeParty")
+    etree.SubElement(seller, f"{{{NSMAP['ram']}}}Name").text = invoice['seller']['name']
+    buyer = etree.SubElement(agreement, f"{{{NSMAP['ram']}}}BuyerTradeParty")
+    etree.SubElement(buyer, f"{{{NSMAP['ram']}}}Name").text = invoice['buyer']['name']
+
+    etree.SubElement(trn, f"{{{NSMAP['ram']}}}ApplicableHeaderTradeDelivery")
+
+    settlement = etree.SubElement(trn, f"{{{NSMAP['ram']}}}ApplicableHeaderTradeSettlement")
+    etree.SubElement(settlement, f"{{{NSMAP['ram']}}}InvoiceCurrencyCode").text = invoice['currency']
+    tax_e = etree.SubElement(settlement, f"{{{NSMAP['ram']}}}ApplicableTradeTax")
+    etree.SubElement(tax_e, f"{{{NSMAP['ram']}}}TypeCode").text = 'VAT'
+    etree.SubElement(tax_e, f"{{{NSMAP['ram']}}}CategoryCode").text = 'S'
+    etree.SubElement(tax_e, f"{{{NSMAP['ram']}}}RateApplicablePercent").text = f"{invoice['items'][0]['tax_rate']:.2f}"
+
+    summ = etree.SubElement(settlement, f"{{{NSMAP['ram']}}}SpecifiedTradeSettlementHeaderMonetarySummation")
+    etree.SubElement(summ, f"{{{NSMAP['ram']}}}LineTotalAmount").text = f"{line_total:.2f}"
+    etree.SubElement(summ, f"{{{NSMAP['ram']}}}TaxBasisTotalAmount").text = f"{line_total:.2f}"
+    etree.SubElement(summ, f"{{{NSMAP['ram']}}}TaxTotalAmount", currencyID=invoice['currency']).text = f"{tax_total:.2f}"
+    grand = line_total + tax_total
+    etree.SubElement(summ, f"{{{NSMAP['ram']}}}GrandTotalAmount").text = f"{grand:.2f}"
+    etree.SubElement(summ, f"{{{NSMAP['ram']}}}DuePayableAmount").text = f"{grand:.2f}"
+
+    return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding='UTF-8').decode()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI, Response
+from pydantic import BaseModel, Field
+from typing import List
+from facturx import xml_check_xsd
+from .builder import build_facturx_basic
+
+class Party(BaseModel):
+    name: str
+
+class Item(BaseModel):
+    name: str
+    quantity: float
+    price: float
+    tax_rate: float = 0.0
+    unit_code: str = Field('C62', description="UNECE unit code")
+
+class Invoice(BaseModel):
+    invoice_id: str
+    issue_date: str
+    currency: str = 'EUR'
+    seller: Party
+    buyer: Party
+    items: List[Item]
+
+app = FastAPI()
+
+@app.post('/generate_facturx')
+def generate_facturx(invoice: Invoice):
+    xml = build_facturx_basic(invoice.model_dump())
+    xml_check_xsd(xml, flavor='factur-x', level='basic')
+    return Response(content=xml, media_type='application/xml')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+factur-x
+fastapi
+uvicorn

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,18 @@
+from facturx import xml_check_xsd
+from app.builder import build_facturx_basic
+
+sample_invoice = {
+    'invoice_id': 'INV-1',
+    'issue_date': '20240317',
+    'currency': 'EUR',
+    'seller': {'name': 'Seller Corp'},
+    'buyer': {'name': 'Buyer Inc'},
+    'items': [
+        {'name': 'Product', 'quantity': 1, 'price': 100.0, 'tax_rate': 0.0}
+    ]
+}
+
+def test_build_facturx_basic():
+    xml = build_facturx_basic(sample_invoice)
+    assert '<rsm:CrossIndustryInvoice' in xml
+    xml_check_xsd(xml, flavor='factur-x', level='basic')


### PR DESCRIPTION
## Summary
- build Factur-X BASIC profile XML invoices from structured data
- expose FastAPI endpoint to return validated XML
- test generator against official XSD

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abb872cb1883229a27dcfaa611120b